### PR TITLE
Update ws2812_control.cpp

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.4.0
+version: 1.4.1
 license: "MIT"
 description: ws2812_control
 url: https://github.com/NingZiXi/ws2812_control

--- a/ws2812_control.cpp
+++ b/ws2812_control.cpp
@@ -522,7 +522,7 @@ ws2812_matrix_t* ws2812_matrix_create() {
     #endif
 
     // 初始化RMT配置
-    rmt_config_t config = RMT_DEFAULT_CONFIG_TX(CONFIG_WS2812_TX_GPIO, RMT_TX_CHANNEL);
+    rmt_config_t config = RMT_DEFAULT_CONFIG_TX((gpio_num_t)CONFIG_WS2812_TX_GPIO, RMT_TX_CHANNEL);
     config.clk_div = 2;
 
     ESP_ERROR_CHECK(rmt_config(&config));


### PR DESCRIPTION
引脚配置数据未进行转换，导致编译错误